### PR TITLE
ねこ編集機能

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -397,10 +397,10 @@ form input[type="submit"]:hover {
 .button-container {
   text-align: center; /* 子要素を中央揃え */
   margin-top: 20px; /* 全体の上余白 */
+  font-size: 12px;
 }
 
 .button-back {
-  font-size: 12px;
   background-color: #c55d13; /* 背景色 */
   color: #fff; /* 文字色 */
   border: none; /* 枠線なし */

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -394,5 +394,26 @@ form input[type="submit"]:hover {
   margin-bottom: 20px;
 }
 
+.button-container {
+  text-align: center; /* 子要素を中央揃え */
+  margin-top: 20px; /* 全体の上余白 */
+}
 
+.button-back {
+  font-size: 12px;
+  background-color: #c55d13; /* 背景色 */
+  color: #fff; /* 文字色 */
+  border: none; /* 枠線なし */
+  cursor: pointer; /* ポインタをクリック可能に */
+  padding: 10px 20px; /* 内側の余白 */
+  text-decoration: none; /* テキスト装飾を消す */
+  display: inline-block; /* インラインブロックにする */
+  text-align: center; /* テキストを中央揃え */
+  border-radius: 5px; /* 角を丸くする */
+  margin: 0 auto;
+}
 
+/* ホバー時のスタイル */
+.button-back:hover {
+  background-color: #a04d10; /* 少し暗い色に変更 */
+}

--- a/app/controllers/cats_controller.rb
+++ b/app/controllers/cats_controller.rb
@@ -1,6 +1,6 @@
 class CatsController < ApplicationController
   before_action :authenticate_user!
-  # before_action :set_cat, only: [:edit, :update, :destroy]
+  before_action :set_cat, only: [:edit, :update]
   before_action :set_form_data, only: [:new, :create]
   def index
     @user = User.find(params[:id]) # この部分を確認
@@ -29,18 +29,17 @@ class CatsController < ApplicationController
     @cat = @user.cats.find(params[:id])
   end
 
-  # def edit
-  #   @ages = Age.all
-  #   @breeds = Breed.all
-  # end
+  def edit
+    @cat = @user.cats.find(params[:id])
+  end
 
-  # def update
-  #   if @cat.update(cat_params)
-  #     redirect_to mypage_user_path(current_user), notice: '猫情報が更新されました！'
-  #   else
-  #     render :edit
-  #   end
-  # end
+  def update
+    if @cat.update(cat_params)
+      redirect_to mypage_user_path(current_user), notice: '猫情報が更新されました！'
+    else
+      render :edit
+    end
+  end
 
   # def destroy
   #   @cat.destroy
@@ -50,10 +49,13 @@ class CatsController < ApplicationController
   private
 
   def set_cat
-    @user = User.find(params[:id]) # パラメータからユーザーを取得
-    return unless @user.nil?
+    @user = User.find_by(id: params[:user_id])
+    redirect_to root_path, alert: 'ユーザーが見つかりません。' and return unless @user
 
-    redirect_to root_path, alert: 'ユーザーが見つかりません。'
+    @cat = @user.cats.find_by(id: params[:id])
+    return if @cat
+
+    redirect_to user_mypage_path(@user), alert: '猫が見つかりません。' and return
   end
 
   def set_form_data

--- a/app/views/cats/edit.html.erb
+++ b/app/views/cats/edit.html.erb
@@ -1,0 +1,32 @@
+<div class="container">
+  <h1>ねこの編集</h1>
+
+  <%= form_with model: [@user, @cat], local: true do |f| %>
+    <div>
+      <%= f.label :name, "名前" %>
+      <%= f.text_field :name, class: "form-control" %>
+    </div>
+
+    <div>
+      <%= f.label :age_id, "年齢" %>
+      <%= f.select :age_id, Age.all.pluck(:name, :id), { include_blank: "選択してください" }, class: "form-control" %>
+    </div>
+
+    <div>
+      <%= f.label :breed_id, "品種" %>
+      <%= f.select :breed_id, Breed.all.pluck(:name, :id), { include_blank: "選択してください" }, class: "form-control" %>
+    </div>
+
+    <div>
+      <%= f.label :image, "写真" %>
+      <%= f.file_field :image, class: "form-control" %>
+    </div>
+
+    <div>
+      <%= f.submit "更新する", class: "button-submit" %>
+    </div>
+  <% end %>
+    <div class="button-container">
+      <%= link_to "戻る", user_cat_path(@user, @cat), class: "button-back" %>
+    </div>
+</div>

--- a/app/views/cats/show.html.erb
+++ b/app/views/cats/show.html.erb
@@ -17,7 +17,7 @@
     </div>
     
     <div class="cat-detail-buttons">
-      <%# <%= link_to '編集する', edit_user_cat_path(@user, @cat), class: 'button button-edit' %>
+      <%= link_to '編集する', edit_user_cat_path(@user, @cat), class: 'button button-edit' %>
       <%# <%= link_to '削除する', user_cat_path(@user, @cat), method: :delete, data: { confirm: '本当に削除しますか？' }, class: 'button button-delete' %>
       <%= link_to '一覧に戻る', mypage_user_path(@user), class: 'button button-back' %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,6 @@ Rails.application.routes.draw do
     member do
       get 'mypage', to: 'cats#index', as: :mypage
     end
-    resources :cats, only: [:new, :create, :show]
+    resources :cats, only: [:new, :create, :show, :edit, :update]
   end
 end


### PR DESCRIPTION
#What
-ねこの編集機能を追加
-CatsControllerにeditとupdateアクションを実装。
-該当するねこの情報を更新できるようにしました。
-不正なアクセスを防ぐため、before_actionで適切な権限チェックを追加。
-編集画面のビューを作成
-app/views/cats/edit.html.erbファイルを作成。
-編集フォームに既存の情報が自動入力されるように設定。
-更新ボタンと戻るボタンを設置し、操作性を向上。

#Why
-アプリのUX向上のため、ユーザーが登録したねこの情報を後から編集できるようにするため。
-誤入力や情報更新の柔軟な対応を可能にすることで、ユーザー満足度を高める。
-他のユーザーの情報を編集されないように認可機能を強化する必要があったため。

ねこ編集ページで編集ができ一覧に戻る動画
https://gyazo.com/98282bb75a94426bdebd058b89d2e68a
ねこ編集画面で戻るボタンを押すとねこ詳細画面に戻る動画
https://gyazo.com/e62c45f0c59c38ef0a818bc53f5c35ef