### PR TITLE
ねこ削除機能

### DIFF
--- a/app/controllers/cats_controller.rb
+++ b/app/controllers/cats_controller.rb
@@ -1,6 +1,6 @@
 class CatsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_cat, only: [:edit, :update]
+  before_action :set_cat, only: [:edit, :update, :destroy]
   before_action :set_form_data, only: [:new, :create]
   def index
     @user = User.find(params[:id]) # この部分を確認
@@ -41,10 +41,10 @@ class CatsController < ApplicationController
     end
   end
 
-  # def destroy
-  #   @cat.destroy
-  #   redirect_to mypage_user_path(current_user), notice: '猫情報が削除されました。'
-  # end
+  def destroy
+    @cat.destroy
+    redirect_to mypage_user_path(@user), notice: '猫情報が削除されました。'
+  end
 
   private
 

--- a/app/views/cats/show.html.erb
+++ b/app/views/cats/show.html.erb
@@ -1,6 +1,6 @@
 <div class="">
   <div class="cat-detail-container">
-  <h1 class="cat-detail-title"><%= @cat.name %> の詳細ページ</h1>
+  <h1 class="cat-detail-title"><%= @cat.name %> の詳細</h1>
 
   <div class="cat-detail-content">
     <div class="cat-detail-info">
@@ -18,7 +18,7 @@
     
     <div class="cat-detail-buttons">
       <%= link_to '編集する', edit_user_cat_path(@user, @cat), class: 'button button-edit' %>
-      <%# <%= link_to '削除する', user_cat_path(@user, @cat), method: :delete, data: { confirm: '本当に削除しますか？' }, class: 'button button-delete' %>
+      <%= link_to '削除する', user_cat_path(@user, @cat), data: { turbo_method: :delete },class: 'button button-delete' %>
       <%= link_to '一覧に戻る', mypage_user_path(@user), class: 'button button-back' %>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,6 @@ Rails.application.routes.draw do
     member do
       get 'mypage', to: 'cats#index', as: :mypage
     end
-    resources :cats, only: [:new, :create, :show, :edit, :update]
+    resources :cats, only: [:new, :create, :show, :edit, :update, :destroy]
   end
 end


### PR DESCRIPTION
#Why
-ユーザーが登録したねこの情報を管理する上で、不要なねこデータを削除できるようにするため。
-ユーザーエクスペリエンスを向上させるため、削除後に適切なリダイレクトと通知を行う仕組みを実装する必要があったため。
What
-ねこ削除機能を実装し、登録済みのねこを削除できるようにした。
-destroy アクションを CatsController に追加し、@user の関連するねこを削除する処理を実装。
-削除後はユーザーのマイページにリダイレクトされるように設定。
-以下の要素を含む実装を行った:
-コントローラ:destroy アクションで該当するねこを検索し削除する処理を追加。
-ルーティング:resources :cats に destroy アクションを追加。
-ビュー:ねこ詳細ページに削除ボタンを追加。

削除ボタンを押すとマイページねこ一覧に戻る動画
https://gyazo.com/5d591b43c94bd3719d05f1a9effe4d95
ログインしていない状態でねこ詳細画面に直接アクセスするとログイン画面に遷移する動画
https://gyazo.com/ab4d8f57073e5f3c35680d5fc9536201