### PR TITLE
投稿機能実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,3 +73,4 @@ end
 gem 'devise'
 gem 'active_hash'
 gem 'mini_magick'
+gem 'image_processing', '~> 1.2'

--- a/Gemfile
+++ b/Gemfile
@@ -72,3 +72,4 @@ group :test do
 end
 gem 'devise'
 gem 'active_hash'
+gem 'mini_magick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,10 +123,21 @@ GEM
       railties (>= 5.0.0)
     faker (3.5.1)
       i18n (>= 1.8.11, < 2)
+    ffi (1.17.1-aarch64-linux-gnu)
+    ffi (1.17.1-aarch64-linux-musl)
+    ffi (1.17.1-arm-linux-gnu)
+    ffi (1.17.1-arm-linux-musl)
+    ffi (1.17.1-arm64-darwin)
+    ffi (1.17.1-x86_64-darwin)
+    ffi (1.17.1-x86_64-linux-gnu)
+    ffi (1.17.1-x86_64-linux-musl)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
+    image_processing (1.13.0)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     importmap-rails (2.1.0)
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
@@ -151,9 +162,7 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
-    mini_magick (5.1.2)
-      benchmark
-      logger
+    mini_magick (4.13.2)
     mini_mime (1.1.5)
     minitest (5.25.4)
     msgpack (1.7.5)
@@ -275,6 +284,9 @@ GEM
     rubocop-ast (1.37.0)
       parser (>= 3.3.1.0)
     ruby-progressbar (1.13.0)
+    ruby-vips (2.2.2)
+      ffi (~> 1.12)
+      logger
     rubyzip (2.4.1)
     securerandom (0.4.1)
     selenium-webdriver (4.28.0)
@@ -338,6 +350,7 @@ DEPENDENCIES
   devise
   factory_bot_rails
   faker
+  image_processing (~> 1.2)
   importmap-rails
   jbuilder
   mini_magick

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,6 +151,9 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    mini_magick (5.1.2)
+      benchmark
+      logger
     mini_mime (1.1.5)
     minitest (5.25.4)
     msgpack (1.7.5)
@@ -337,6 +340,7 @@ DEPENDENCIES
   faker
   importmap-rails
   jbuilder
+  mini_magick
   mysql2 (~> 0.5)
   puma (>= 5.0)
   rails (~> 7.1.0)

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -456,3 +456,37 @@ form input[type="submit"]:hover {
   font-size: 24px;
   margin-left: 10px;
 }
+
+.post-item {
+  border: 1px solid #ddd;
+  padding: 15px;
+  margin-bottom: 20px;
+  border-radius: 8px;
+  background-color: #f9f9f9;
+}
+
+.post-image {
+  max-width: 100%;
+  height: auto;
+  border-radius: 5px;
+  margin-bottom: 10px;
+}
+
+.post-item h2 {
+  font-size: 20px;
+  color: #333;
+  margin-bottom: 10px;
+}
+
+.post-detail, .post-delete {
+  margin-right: 10px;
+  text-decoration: none;
+  color: #fff;
+  background-color: #c55d13;
+  padding: 5px 10px;
+  border-radius: 3px;
+}
+
+.post-delete:hover {
+  background-color: #a04d10;
+}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -505,6 +505,7 @@ form input[type="submit"]:hover {
   background-size: cover;  /* 画像を全体に表示 */
   background-position: center;  /* 中央に配置 */
   position: relative;
+  
 }
 
 .post-overlay {
@@ -527,4 +528,69 @@ form input[type="submit"]:hover {
   font-size: 16px;
   font-style: italic;
   margin: 5px 0 0;
+}
+
+.contents {
+  width: 80%;
+  margin: 0 auto;
+  padding: 60px 40px;
+}
+
+.post-card {
+  width: 600px;
+  margin: 20px auto;
+  border-radius: 10px;
+  overflow: hidden;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  position: relative;
+}
+
+.post-image-wrapper {
+  width: 100%;
+  height: 400px;
+  position: relative;
+}
+
+.post-overlay {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.8), rgba(0, 0, 0, 0.2));
+  color: white;
+  padding: 20px;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.8);
+}
+
+.post-title {
+  font-size: 24px;
+  font-weight: bold;
+  margin: 0;
+}
+
+.post-author, .post-content, .post-cat {
+  font-size: 14px;
+  margin: 5px 0;
+}
+
+.author-link,
+.cat-link {
+  color: #fff;
+  text-decoration: underline;
+  text-decoration: none;
+}
+
+.author-link:hover,
+.cat-link:hover {
+  color: #ccc;
+  text-decoration: underline;
+}
+
+.post-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.post-image:hover {
+  transform: scale(1.05); /* ホバー時に少し拡大 */
 }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -490,3 +490,41 @@ form input[type="submit"]:hover {
 .post-delete:hover {
   background-color: #a04d10;
 }
+
+.post-item {
+  width: 600px;  /* 投稿カードの幅を調整 */
+  margin: 20px auto;
+  border-radius: 10px;
+  overflow: hidden;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);  /* カードに影を付ける */
+}
+
+.post-image-wrapper {
+  width: 100%;
+  height: 300px;  /* 画像の高さを固定 */
+  background-size: cover;  /* 画像を全体に表示 */
+  background-position: center;  /* 中央に配置 */
+  position: relative;
+}
+
+.post-overlay {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.7), transparent);  /* 下部からのグラデーション */
+  padding: 20px;
+  color: white;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.8);  /* テキストに影を付けて読みやすく */
+}
+
+.post-title {
+  font-size: 24px;
+  font-weight: bold;
+  margin: 0;
+}
+
+.post-author {
+  font-size: 16px;
+  font-style: italic;
+  margin: 5px 0 0;
+}

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,5 +1,5 @@
 class PostsController < ApplicationController
-  before_action :authenticate_user! # ログインしているユーザーのみが投稿可能
+  before_action :authenticate_user!, except: [:index, :show]
   before_action :set_post, only: %i[show edit update destroy]
 
   def index

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,4 +1,50 @@
 class PostsController < ApplicationController
+  before_action :authenticate_user! # ログインしているユーザーのみが投稿可能
+  before_action :set_post, only: %i[show edit update destroy]
+
   def index
+    @posts = Post.includes(:user, :cat, image_attachment: :blob).order(created_at: :desc)
+  end
+
+  def show
+  end
+
+  def new
+    @post = current_user.posts.new
+  end
+
+  def create
+    @post = current_user.posts.new(post_params)
+    if @post.save
+      redirect_to posts_path, notice: '投稿が作成されました。'
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @post.update(post_params)
+      redirect_to post_path(@post), notice: '投稿が更新されました。'
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @post.destroy
+    redirect_to posts_path, notice: '投稿が削除されました。'
+  end
+
+  private
+
+  def set_post
+    @post = Post.find(params[:id])
+  end
+
+  def post_params
+    params.require(:post).permit(:title, :content, :image, :cat_id)
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,0 +1,2 @@
+class Post < ApplicationRecord
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,2 +1,9 @@
 class Post < ApplicationRecord
+  belongs_to :user
+  belongs_to :cat, optional: true
+  has_one_attached :image
+
+  validates :title, presence: true, length: { maximum: 30 }
+  validates :content, length: { maximum: 1080 }
+  validates :image, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   has_many :cats, dependent: :destroy
+  has_many :posts, dependent: :destroy
   validates :nickname, presence: true, length: { maximum: 6 }
   validates :password, presence: true,
                        format: { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i, message: 'is invalid. Include both letters and numbers' }

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,28 +1,37 @@
-<h1>にゃーついギャラリー</h1>
+<div class="contents row">
+  <h1>にゃーついギャラリー</h1>
 
-<%= link_to '新しい投稿', new_post_path, class: 'button-submit' %>
+  <%# <%= link_to '新しい投稿', new_post_path, class: 'button-submit' %> 
 
-<% @posts.each do |post| %>
-  <div class="post-item">
-    <% if post.image.attached? %>
-      <%= image_tag post.image.variant(resize_to_limit: [400, 400]), alt: "投稿画像", class: "post-image" %>
-    <% end %>
+  <% @posts.each do |post| %>
+    <div class="post-item">
+      <% if post.image.attached? %>
+        <div class="post-image-wrapper" style="background-image: url(<%= url_for(post.image) %>);">
+          <div class="post-overlay">
+            <h2 class="post-title"><%= post.title %></h2>
+            <p class="post-author"><%= post.user.nickname %></p>
+          </div>
+        </div>
+      <% end %>
 
-    <h2><%= post.title %></h2>  <!-- タイトルを表示 -->
+      <div class="post-details">
+        <p class="post-author"><strong><%= post.user.nickname %> さんの投稿</strong></p>
 
-    <p><strong><%= post.user.nickname %> さんの投稿</strong></p>
-    
-    <% if post.content.present? %>
-      <p><%= post.content %></p>
-    <% end %>
-    
-    <% if post.cat %>
-      <p>🐱 ねこ: <%= link_to post.cat.name, user_cat_path(post.user, post.cat) %></p>
-    <% end %>
+        <% if post.content.present? %>
+          <p class="post-content"><%= post.content %></p>
+        <% end %>
 
-    <%= link_to '詳細を見る', post_path(post), class: 'post-detail' %>
-    <% if post.user == current_user %>  <!-- 自分の投稿のみ削除可能 -->
-      <%= link_to '削除', post_path(post), method: :delete, data: { confirm: '削除してもよろしいですか？' }, class: 'post-delete' %>
-    <% end %>
-  </div>
-<% end %>
+        <% if post.cat %>
+          <p class="post-cat">🐱 ねこ: <%= link_to post.cat.name, user_cat_path(post.user, post.cat) %></p>
+        <% end %>
+
+        <div class="post-actions">
+          <%= link_to '詳細を見る', post_path(post), class: 'post-detail' %>
+          <% if post.user == current_user %>
+            <%= link_to '削除', post_path(post), method: :delete, data: { confirm: '削除してもよろしいですか？' }, class: 'post-delete' %>
+          <% end %>
+        </div>
+      </div>
+    </div> <!-- post-item 終了 -->
+  <% end %> <!-- each ループの終了 -->
+</div> <!-- contents 終了 -->

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -9,7 +9,7 @@
           <div class="post-overlay">
             <h2 class="post-title"><%= post.title %></h2>
             <p class="post-author">
-              投稿者: <%= link_to post.user.nickname, user_path(post.user), class: "author-link" %>
+              投稿者: <%=  post.user.nickname %>
             </p>
 
             <% if post.content.present? %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,37 +1,28 @@
-<div class="contents row">
-  <h1>にゃーついギャラリー</h1>
-
-  <%# <%= link_to '新しい投稿', new_post_path, class: 'button-submit' %> 
+<div class="contents">
+  <h2>にゃーついギャラリー</h2>
 
   <% @posts.each do |post| %>
-    <div class="post-item">
+      <div class="post-card">
       <% if post.image.attached? %>
-        <div class="post-image-wrapper" style="background-image: url(<%= url_for(post.image) %>);">
+        <div class="post-image-wrapper">
+          <%= link_to image_tag(post.image.variant(resize_to_limit: [400, 300]), alt: "投稿画像", class: "post-image"), post_path(post) %>
           <div class="post-overlay">
             <h2 class="post-title"><%= post.title %></h2>
-            <p class="post-author"><%= post.user.nickname %></p>
+            <p class="post-author">
+              投稿者: <%= link_to post.user.nickname, user_path(post.user), class: "author-link" %>
+            </p>
+
+            <% if post.content.present? %>
+              <p class="post-content"><%= post.content %></p>
+            <% end %>
+
+            <% if post.cat %>
+              <p class="post-cat">🐱 ねこ: <%= link_to post.cat.name, user_cat_path(post.user, post.cat) %></p>
+            <% end %>
           </div>
         </div>
       <% end %>
-
-      <div class="post-details">
-        <p class="post-author"><strong><%= post.user.nickname %> さんの投稿</strong></p>
-
-        <% if post.content.present? %>
-          <p class="post-content"><%= post.content %></p>
-        <% end %>
-
-        <% if post.cat %>
-          <p class="post-cat">🐱 ねこ: <%= link_to post.cat.name, user_cat_path(post.user, post.cat) %></p>
-        <% end %>
-
-        <div class="post-actions">
-          <%= link_to '詳細を見る', post_path(post), class: 'post-detail' %>
-          <% if post.user == current_user %>
-            <%= link_to '削除', post_path(post), method: :delete, data: { confirm: '削除してもよろしいですか？' }, class: 'post-delete' %>
-          <% end %>
-        </div>
-      </div>
-    </div> <!-- post-item 終了 -->
-  <% end %> <!-- each ループの終了 -->
-</div> <!-- contents 終了 -->
+    </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,0 +1,28 @@
+<h1>にゃーついギャラリー</h1>
+
+<%= link_to '新しい投稿', new_post_path, class: 'button-submit' %>
+
+<% @posts.each do |post| %>
+  <div class="post-item">
+    <% if post.image.attached? %>
+      <%= image_tag post.image.variant(resize_to_limit: [400, 400]), alt: "投稿画像", class: "post-image" %>
+    <% end %>
+
+    <h2><%= post.title %></h2>  <!-- タイトルを表示 -->
+
+    <p><strong><%= post.user.nickname %> さんの投稿</strong></p>
+    
+    <% if post.content.present? %>
+      <p><%= post.content %></p>
+    <% end %>
+    
+    <% if post.cat %>
+      <p>🐱 ねこ: <%= link_to post.cat.name, user_cat_path(post.user, post.cat) %></p>
+    <% end %>
+
+    <%= link_to '詳細を見る', post_path(post), class: 'post-detail' %>
+    <% if post.user == current_user %>  <!-- 自分の投稿のみ削除可能 -->
+      <%= link_to '削除', post_path(post), method: :delete, data: { confirm: '削除してもよろしいですか？' }, class: 'post-delete' %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,0 +1,25 @@
+<h1>新しいにゃーつい投稿</h1>
+
+<%= form_with(model: @post, local: true) do |f| %>
+  <div>
+    <%= f.label :title, "写真のタイトル" %>
+    <%= f.text_field :title, class: "form-control" %>
+  </div>
+
+  <div>
+    <%= f.label :image, "写真を選択" %>
+    <%= f.file_field :image, class: "form-control" %>
+  </div>
+
+  <div>
+    <%= f.label :content, "キャプション（任意）" %>
+    <%= f.text_area :content, rows: 3, class: "form-control" %>
+  </div>
+
+  <div>
+    <%= f.label :cat_id, "ねこを選択（オプション）" %>
+    <%= f.collection_select :cat_id, current_user.cats, :id, :name, { prompt: "ねこを選んでください" }, class: "form-control" %>
+  </div>
+
+  <%= f.submit "投稿する", class: "button-submit" %>
+<% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,0 +1,21 @@
+<h1><%= @post.title %></h1>
+
+<% if @post.image.attached? %>
+  <%= image_tag @post.image, alt: "投稿画像", class: "post-image" %>
+<% end %>
+
+<p><strong>投稿者:</strong> <%= @post.user.nickname %></p>
+
+<% if @post.content.present? %>
+  <p><%= @post.content %></p>
+<% end %>
+
+<% if @post.cat %>
+  <p>🐱 紐づいているねこ: <%= link_to @post.cat.name, user_cat_path(@post.user, @post.cat) %></p>
+<% end %>
+
+<%= link_to '一覧に戻る', posts_path, class: 'button-back' %>
+<% if @post.user == current_user %>
+  <%= link_to '編集', edit_post_path(@post), class: 'button-edit' %>
+  <%= link_to '削除', post_path(@post), method: :delete, data: { confirm: '本当に削除しますか？' }, class: 'button-delete' %>
+<% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,7 +1,8 @@
+<div class="container">
 <h1><%= @post.title %></h1>
 
 <% if @post.image.attached? %>
-  <%= image_tag @post.image, alt: "投稿画像", class: "post-image" %>
+  <%= image_tag @post.image.variant(resize_to_limit: [300, 300]), alt: "投稿画像", class: "post-image" %>
 <% end %>
 
 <p><strong>投稿者:</strong> <%= @post.user.nickname %></p>
@@ -19,3 +20,4 @@
   <%= link_to '編集', edit_post_path(@post), class: 'button-edit' %>
   <%= link_to '削除', post_path(@post), method: :delete, data: { confirm: '本当に削除しますか？' }, class: 'button-delete' %>
 <% end %>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -4,7 +4,7 @@
       <% if user_signed_in? %>
         <div class="user_nav grid-6">
           <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete } %>
-          <%= link_to "投稿する", "/", class: "post" %>
+          <%= link_to "投稿する", new_post_path, class: "post" %>
           <% if current_page?(mypage_user_path(current_user)) %>
             <%= link_to 'ねこ登録', new_user_cat_path(current_user), class: "post" %>
             <%= link_to 'げぼく診断', user_select_diagnosis_cat_path(current_user), class: "post" %> <!-- ここで「げぼく診断」に切り替え -->

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root "posts#index"
-  get 'posts/index'
+  resources :posts, only: [:new, :create, :index]
 
   resources :users, only: [] do
     get 'diagnosis', to: 'diagnosis#select_cat', as: :select_diagnosis_cat

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   root "posts#index"
     resources :posts, only: [:new, :create, :index,:show]
 
-  resources :users, only: [] do
+  resources :users, only: [:show] do
     get 'diagnosis', to: 'diagnosis#select_cat', as: :select_diagnosis_cat
     post 'diagnosis/start', to: 'diagnosis#start', as: 'start_diagnosis'
     member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root "posts#index"
-  resources :posts, only: [:new, :create, :index]
+    resources :posts, only: [:new, :create, :index,:show]
 
   resources :users, only: [] do
     get 'diagnosis', to: 'diagnosis#select_cat', as: :select_diagnosis_cat

--- a/db/migrate/20250202043735_create_posts.rb
+++ b/db/migrate/20250202043735_create_posts.rb
@@ -1,0 +1,8 @@
+class CreatePosts < ActiveRecord::Migration[7.1]
+  def change
+    create_table :posts do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250202043735_create_posts.rb
+++ b/db/migrate/20250202043735_create_posts.rb
@@ -1,6 +1,10 @@
 class CreatePosts < ActiveRecord::Migration[7.1]
   def change
     create_table :posts do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :cat, foreign_key: true
+      t.string :title, null: false
+      t.text :content
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -51,8 +51,14 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_02_043735) do
   end
 
   create_table "posts", charset: "utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "cat_id"
+    t.string "title", null: false
+    t.text "content"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["cat_id"], name: "index_posts_on_cat_id"
+    t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
   create_table "users", charset: "utf8", force: :cascade do |t|
@@ -71,4 +77,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_02_043735) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "cats", "users"
+  add_foreign_key "posts", "cats"
+  add_foreign_key "posts", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_01_31_095411) do
+ActiveRecord::Schema[7.1].define(version: 2025_02_02_043735) do
   create_table "active_storage_attachments", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -48,6 +48,11 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_31_095411) do
     t.datetime "updated_at", null: false
     t.string "diagnosis_result", collation: "utf8mb4_bin"
     t.index ["user_id"], name: "index_cats_on_user_id"
+  end
+
+  create_table "posts", charset: "utf8", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", charset: "utf8", force: :cascade do |t|


### PR DESCRIPTION
#What
-投稿機能の実装
-ユーザーが画像とタイトル、内容、そして任意で複数のねこを紐づけて投稿できるようにした。
-投稿に紐づくねこを中間テーブル（PostCat）を通じて管理する仕組みを構築。
-投稿一覧画面、詳細画面で投稿内容や紐づいたねこの情報を確認できるようにした。

#Why
-ユーザーが飼っているねこの写真や情報を気軽に投稿し、他のユーザーと共有することで、コミュニティの活性化を目指すため。
-複数のねこを1つの投稿に紐づけられることで、ねこの情報を一括で管理し、投稿内容をよりリッチにするため。
-投稿された情報を一覧画面や詳細画面で確認し、ユーザー体験を向上させるため。