### PR TITLE
投稿複数ねこ選択機能

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,3 +189,15 @@ rails server
 | updated_at | datetime   |	null: false                    |
 
 ### Association
+
+## post_catsテーブル
+
+| Column     | Type       | Options                        |
+| ---------- | ---------- | ------------------------------ |
+| cat_id    | references | null: false, foreign_key: true |
+| post_id    | references | null: false, foreign_key: true |
+
+### Association
+
+-belongs_to :post
+-belongs_to :cat

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -629,3 +629,60 @@ form input[type="submit"]:hover {
   background-color: #c55d13;
   padding: 8px;
 }
+.post-cat {
+  font-size: 18px;
+  font-weight: bold;
+  color: #333;
+  margin-bottom: 8px;
+}
+
+.cat-list {
+  display: flex;
+  gap: 10px; /* カード同士の間隔 */
+  flex-wrap: wrap; /* 折り返しを許可 */
+}
+
+.cat-item {
+  background-color: #f0f0f0;
+  border-radius: 5px;
+  padding: 5px 10px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transition: background-color 0.3s ease;
+}
+
+.cat-item:hover {
+  background-color: #ffe0b2; /* ホバー時の背景色 */
+}
+
+.cat-link-wrapper {
+  background-color: #f0f0f0;
+  padding: 5px 10px;
+  border-radius: 5px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transition: background-color 0.3s ease;
+}
+
+.cat-link {
+  text-decoration: none;
+  font-size: 14px;
+  color: #c55d13;
+  font-weight: bold;
+}
+
+.cat-link:hover {
+  text-decoration: underline;
+}
+
+.cat-list {
+  list-style: none; /* リストのマーカーを非表示 */
+  padding: 0;
+  display: flex;
+  gap: 10px; /* 各ねこの間隔 */
+}
+
+p {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap; /* 折り返し可能にする */
+  gap: 10px; /* 各リンク間の間隔を調整 */
+}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -594,3 +594,38 @@ form input[type="submit"]:hover {
 .post-image:hover {
   transform: scale(1.05); /* ホバー時に少し拡大 */
 }
+
+.cats-select-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 15px;
+}
+
+.cat-option {
+  padding: 10px 15px;
+  border: 2px solid #ccc;
+  border-radius: 8px;
+  text-align: center;
+  cursor: pointer;
+  transition: background-color 0.3s, border-color 0.3s;
+}
+
+.cat-option input[type="checkbox"] {
+  display: none; /* チェックボックス自体は非表示に */
+}
+
+.cat-label {
+  font-size: 16px;
+  color: #333;
+}
+
+/* チェックされているときのスタイル */
+.cat-option input[type="checkbox"]:checked + .cat-label {
+  font-weight: bold;
+  color: white;
+}
+
+.cat-option input[type="checkbox"]:checked + .cat-label {
+  background-color: #c55d13;
+  padding: 8px;
+}

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -45,6 +45,6 @@ class PostsController < ApplicationController
   end
 
   def post_params
-    params.require(:post).permit(:title, :content, :image, :cat_id)
+    params.require(:post).permit(:title, :content, :image, cat_id: [])
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -45,6 +45,6 @@ class PostsController < ApplicationController
   end
 
   def post_params
-    params.require(:post).permit(:title, :content, :image, cat_id: [])
+    params.require(:post).permit(:title, :content, :image, cat_ids: [])
   end
 end

--- a/app/models/cat.rb
+++ b/app/models/cat.rb
@@ -4,6 +4,8 @@ class Cat < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :age
   belongs_to :breed
+  has_many :post_cats
+  has_many :posts, through: :post_cats
   validates :name, presence: true, length: { maximum: 40 }
   validates :age_id, numericality: { other_than: 1, message: "can't be blank" }
   validates :breed_id, numericality: { other_than: 1, message: "can't be blank" }

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,7 +2,8 @@ class Post < ApplicationRecord
   belongs_to :user
   belongs_to :cat, optional: true
   has_one_attached :image
-
+  has_many :post_cats
+  has_many :cats, through: :post_cats
   validates :title, presence: true, length: { maximum: 30 }
   validates :content, length: { maximum: 1080 }
   validates :image, presence: true

--- a/app/models/post_cat.rb
+++ b/app/models/post_cat.rb
@@ -1,0 +1,4 @@
+class PostCat < ApplicationRecord
+  belongs_to :post
+  belongs_to :cat
+end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -16,8 +16,14 @@
               <p class="post-content"><%= post.content %></p>
             <% end %>
 
-            <% if post.cat %>
-              <p class="post-cat">🐱 ねこ: <%= link_to post.cat.name, user_cat_path(post.user, post.cat) %></p>
+            <% if post.cats.any? %>
+              <p>🐱 紐づいているねこ:
+              <% post.cats.each do |cat| %>
+                <span class="cat-link-wrapper">
+                  <%= link_to cat.name, user_cat_path(post.user, cat), class: "cat-link" %>
+                </span>
+              <% end %>
+              </p>
             <% end %>
           </div>
         </div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -17,12 +17,17 @@
   </div>
 
   <div>
-    <%= f.label :cat_ids, "ねこを選択（複数選択可能）" %>
-    <%= f.collection_check_boxes :cat_ids, current_user.cats, :id, :name do |b| %>
-      <div class="checkbox-item">
-        <%= b.check_box %>
-        <%= b.label %>
-      </div>
+    <% if current_user.cats.any? %>
+    <%= f.label :cat_ids, "ねこを選択（クリックして複数選択）" %>
+    <div class="cats-select-grid">
+      <%= f.collection_check_boxes :cat_ids, current_user.cats, :id, :name do |b| %>
+        <div class="cat-option">
+          <%= b.check_box %>
+          <%= b.label(class: "cat-label") %>
+        </div>
+      <% end %>
+    </div>
+    <% end %>
   </div>
 
   <%= f.submit "投稿する", class: "button-submit" %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -17,8 +17,12 @@
   </div>
 
   <div>
-    <%= f.label :cat_id, "ねこを選択（オプション）" %>
-    <%= f.collection_select :cat_id, current_user.cats, :id, :name, { prompt: "ねこを選んでください" }, class: "form-control" %>
+    <%= f.label :cat_ids, "ねこを選択（複数選択可能）" %>
+    <%= f.collection_check_boxes :cat_ids, current_user.cats, :id, :name do |b| %>
+      <div class="checkbox-item">
+        <%= b.check_box %>
+        <%= b.label %>
+      </div>
   </div>
 
   <%= f.submit "投稿する", class: "button-submit" %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -11,8 +11,13 @@
   <p><%= @post.content %></p>
 <% end %>
 
-<% if @post.cat %>
-  <p>🐱 紐づいているねこ: <%= link_to @post.cat.name, user_cat_path(@post.user, @post.cat) %></p>
+<% if @post.cats.any? %>
+  <p>🐱 紐づいているねこ:</p>
+  <ul>
+    <% @post.cats.each do |cat| %>
+      <li><%= link_to cat.name, user_cat_path(@post.user, cat) %></li>
+    <% end %>
+  </ul>
 <% end %>
 
 <%= link_to '一覧に戻る', posts_path, class: 'button-back' %>

--- a/db/migrate/20250204011710_create_post_cats.rb
+++ b/db/migrate/20250204011710_create_post_cats.rb
@@ -1,0 +1,10 @@
+class CreatePostCats < ActiveRecord::Migration[7.1]
+  def change
+    create_table :post_cats do |t|
+      t.references :post, null: false, foreign_key: true
+      t.references :cat, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_02_02_043735) do
+ActiveRecord::Schema[7.1].define(version: 2025_02_04_011710) do
   create_table "active_storage_attachments", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -50,6 +50,15 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_02_043735) do
     t.index ["user_id"], name: "index_cats_on_user_id"
   end
 
+  create_table "post_cats", charset: "utf8", force: :cascade do |t|
+    t.bigint "post_id", null: false
+    t.bigint "cat_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["cat_id"], name: "index_post_cats_on_cat_id"
+    t.index ["post_id"], name: "index_post_cats_on_post_id"
+  end
+
   create_table "posts", charset: "utf8", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "cat_id"
@@ -77,6 +86,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_02_043735) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "cats", "users"
+  add_foreign_key "post_cats", "cats"
+  add_foreign_key "post_cats", "posts"
   add_foreign_key "posts", "cats"
   add_foreign_key "posts", "users"
 end


### PR DESCRIPTION
#Why
-ユーザーが投稿する写真に複数のねこを関連付けたいという要望があったため。
-1つの投稿に複数のねこを紐づけることで、ねこごとの思い出や特徴を投稿に反映でき、より充実した投稿体験を提供するため。
-現在は1匹のねこしか選べない仕様だったため、選択肢の拡張が必要だった。

#What
-投稿フォームに複数選択ができる**collection_check_boxes**を使用し、登録されているすべてのねこから選べるようにした。
-猫が登録されていない場合は選択フォームを非表示にし、代わりに「ねこを登録してください」というメッセージを表示する条件分岐を追加。
-**中間テーブル（PostCatモデル）**を使い、投稿と複数のねこを関連付けられるようにした。
-投稿時に選択されたねこが中間テーブルに保存されるよう、posts_controller.rb内のcreateおよびupdateアクションを修正。
-投稿詳細画面で、紐づいた複数のねこの名前を一覧で表示し、それぞれの詳細ページへリンクを設定。