### PR TITLE
投稿編集機能

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -557,7 +557,7 @@ form input[type="submit"]:hover {
 
 .contents h2 {
   position: relative;
-  z-index: 10; /* 他の要素より前に表示する */
+ 
 }
 
 h2, p {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -479,12 +479,11 @@ form input[type="submit"]:hover {
   position: relative;
   align-items: center; /* 横方向の中央揃え */
   justify-content: center; /* 縦方向の中央揃え */
-  text-align: center; /* テキストも中央揃え */
 }
 
 .post-image-list {
   width: 600px;
-  height: 500px;
+  height: 400px;
   object-fit: cover; /* サムネイルとしてトリミングする */
   border-radius: 8px; /* 角を丸くするオプション */
 }

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,6 @@
 class PostsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_post, only: %i[show edit update destroy]
+  before_action :set_post, only: [:show, :edit, :update, :destroy]
 
   def index
     @posts = Post.includes(:user, :cat, image_attachment: :blob).order(created_at: :desc)

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,0 +1,34 @@
+<h1>にゃーつい投稿の編集</h1>
+
+<%= form_with(model: @post, local: true) do |f| %>
+  <div>
+    <%= f.label :title, "写真のタイトル" %>
+    <%= f.text_field :title, class: "form-control" %>
+  </div>
+
+  <div>
+    <%= f.label :image, "写真を選択" %>
+    <%= f.file_field :image, class: "form-control" %>
+  </div>
+
+  <div>
+    <%= f.label :content, "キャプション（任意）" %>
+    <%= f.text_area :content, rows: 3, class: "form-control" %>
+  </div>
+
+  <div>
+    <% if current_user.cats.any? %>
+    <%= f.label :cat_ids, "ねこを選択（クリックして複数選択）" %>
+    <div class="cats-select-grid">
+      <%= f.collection_check_boxes :cat_ids, current_user.cats, :id, :name do |b| %>
+        <div class="cat-option">
+          <%= b.check_box %>
+          <%= b.label(class: "cat-label") %>
+        </div>
+      <% end %>
+    </div>
+    <% end %>
+  </div>
+
+  <%= f.submit "更新する", class: "button-submit" %>
+<% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -36,15 +36,4 @@
       <%= link_to '削除', post_path(@post), method: :delete, data: { confirm: '本当に削除しますか？' }, class: 'show-button-delete' %>
     <% end %>
   </div>
-
-  <% if @post.cats.any? %>
-    <p>🐱 紐づいているねこ:</p>
-    <ul>
-      <% @post.cats.each do |cat| %>
-        <li><%= link_to cat.name, user_cat_path(@post.user, cat) %></li>
-      <% end %>
-    </ul>
-  <% end %>
-
-
 </div>


### PR DESCRIPTION
#Why
-ユーザーが投稿した内容に誤りがあった場合や、情報を更新したい場合に対応するため。
-SNSなどの投稿系アプリでは、投稿の修正機能が基本的な操作として必要とされるため。
-投稿に紐づくねこの情報を編集できることで、ねこに関連するデータを一貫性を持って管理できるようにするため。

#What
-投稿のタイトル、内容、画像、紐づいているねこの情報を編集できる機能を実装しました。
-edit アクションと update アクションを PostsController に追加し、編集用のビューを作成しました。
-投稿者のみが投稿を編集できるようにアクセス制御を設定しました。
-編集フォームには、複数のねこを選択できるチェックボックスを実装しています。
-編集後は投稿詳細ページにリダイレクトし、編集内容が反映されるようになっています。