### PR TITLE
コメント削除機能実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -90,3 +90,17 @@
     }
   }
 }
+
+.delete-comment-button {
+  background-color: #e74c3c;
+  color: white;
+  padding: 5px 10px;
+  border: none;
+  border-radius: 4px;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.delete-comment-button:hover {
+  background-color: #c0392b;
+}

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -15,7 +15,8 @@ class CommentsController < ApplicationController
     else
       respond_to do |format|
         format.turbo_stream do
-          render turbo_stream: turbo_stream.replace('comment_form', partial: 'comments/form', locals: { comment: @comment })
+          render turbo_stream: turbo_stream.replace('comment_form', partial: 'comments/form',
+                                                                    locals: { post: @post, comment: @comment })
         end
         format.html { render 'posts/show', alert: 'コメントの追加に失敗しました。' }
       end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,6 +1,7 @@
 class CommentsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_post
+  before_action :set_comment, only: [:destroy]
 
   def create
     @comment = @post.comments.new(comment_params)
@@ -18,6 +19,18 @@ class CommentsController < ApplicationController
         end
         format.html { redirect_to @post, alert: 'コメントの追加に失敗しました。' }
       end
+    end
+  end
+
+  def destroy
+    if @comment.user == current_user || current_user.admin?
+      @comment.destroy
+      respond_to do |format|
+        format.turbo_stream
+        format.html { redirect_to @post, notice: 'コメントを削除しました。' }
+      end
+    else
+      redirect_to @post, alert: '削除する権限がありません。'
     end
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -17,20 +17,22 @@ class CommentsController < ApplicationController
         format.turbo_stream do
           render turbo_stream: turbo_stream.replace('comment_form', partial: 'comments/form', locals: { comment: @comment })
         end
-        format.html { redirect_to @post, alert: 'コメントの追加に失敗しました。' }
+        format.html { render 'posts/show', alert: 'コメントの追加に失敗しました。' }
       end
     end
   end
 
   def destroy
-    if @comment.user == current_user || current_user.admin?
+    if @comment.user == current_user
       @comment.destroy
       respond_to do |format|
         format.turbo_stream
         format.html { redirect_to @post, notice: 'コメントを削除しました。' }
       end
     else
-      redirect_to @post, alert: '削除する権限がありません。'
+      respond_to do |format|
+        format.html { redirect_to @post, alert: '他のユーザーのコメントは削除できません。' }
+      end
     end
   end
 
@@ -38,6 +40,10 @@ class CommentsController < ApplicationController
 
   def set_post
     @post = Post.find(params[:post_id])
+  end
+
+  def set_comment
+    @comment = @post.comments.find(params[:id])
   end
 
   def comment_params

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,10 +3,13 @@ class PostsController < ApplicationController
   before_action :set_post, only: [:show, :edit, :update, :destroy]
 
   def index
-    @posts = Post.includes(:user, :cat, image_attachment: :blob).order(created_at: :desc)
+    @posts = Post.order(created_at: :desc)
   end
 
   def show
+    @post = Post.find(params[:id])
+    @comments = @post.comments.includes(:user)
+    @current_user = current_user # ログイン中のユーザー情報を変数に格納して渡す
   end
 
   def new

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -10,6 +10,7 @@ class PostsController < ApplicationController
     @post = Post.find(params[:id])
     @comments = @post.comments.includes(:user)
     @current_user = current_user # ログイン中のユーザー情報を変数に格納して渡す
+    @comment = Comment.new
   end
 
   def new

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,4 +1,5 @@
 class Comment < ApplicationRecord
   belongs_to :post
   belongs_to :user
+  validates :content, presence: true, length: { maximum: 50, message: 'コメントは50文字以内で入力してください。' }
 end

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,4 +1,11 @@
 <div class="comment">
   <strong><%= comment.user.nickname %></strong>:
   <p><%= comment.content %></p>
+  <% if comment.user == current_user || current_user.admin? %>
+    <%= link_to '削除', post_comment_path(comment.post, comment), 
+                method: :delete, 
+                data: { confirm: '本当に削除しますか？' }, 
+                remote: true, 
+                class: "comment-delete-link" %>
+  <% end %>
 </div>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,8 +1,13 @@
-<div id="comment_<%= comment.id %>" class="comment">
-  <strong><%= comment.user.nickname %>:</strong>
-  <p><%= comment.content %></p>
+<div id="comment_<%= comment.id %>" class="comment" style="display: flex; justify-content: space-between; align-items: center;">
+  <div>
+    <strong><%= comment.user.nickname %>:</strong>
+    <p><%= comment.content %></p>
+  </div>
 
   <% if current_user && comment.user_id.to_i == current_user.id.to_i %>
-    <%= link_to '削除', post_comment_path(comment.post, comment), method: :delete, data: { turbo_confirm: "本当に削除しますか？" }, class: "delete-comment-button" %>
+    <%= link_to '削除', post_comment_path(comment.post, comment), 
+        method: :delete, 
+        data: { turbo_confirm: "本当に削除しますか？" }, 
+        class: "delete-comment-button" %>
   <% end %>
 </div>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,11 +1,8 @@
-<div class="comment">
-  <strong><%= comment.user.nickname %></strong>:
+<div id="comment_<%= comment.id %>" class="comment">
+  <strong><%= comment.user.nickname %>:</strong>
   <p><%= comment.content %></p>
-  <% if comment.user == current_user || current_user.admin? %>
-    <%= link_to '削除', post_comment_path(comment.post, comment), 
-                method: :delete, 
-                data: { confirm: '本当に削除しますか？' }, 
-                remote: true, 
-                class: "comment-delete-link" %>
+
+  <% if current_user && comment.user_id.to_i == current_user.id.to_i %>
+    <%= link_to '削除', post_comment_path(comment.post, comment), method: :delete, data: { turbo_confirm: "本当に削除しますか？" }, class: "delete-comment-button" %>
   <% end %>
 </div>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,0 +1,19 @@
+<%= form_with(model: [post, comment], id: 'comment_form') do |f| %>
+  <% if comment.errors.any? %>
+    <div class="error-messages">
+      <ul>
+        <% comment.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= f.label :content, "コメント:" %>
+    <%= f.text_area :content, rows: 3 %>
+  </div>
+  <div>
+    <%= f.submit "コメントする", class: "comment-submit-button" %>
+  </div>
+<% end %>

--- a/app/views/comments/create.turbo_stream.erb
+++ b/app/views/comments/create.turbo_stream.erb
@@ -1,6 +1,6 @@
 <turbo-stream action="append" target="comments-section">
   <template>
-  <%= render partial: "comments/comment", formats: [:html], locals: { comment: @comment } %>
+  <%= render "comments/comment", comment: @comment %>
   </template>
 </turbo-stream>
 

--- a/app/views/comments/destroy.turbo_stream.erb
+++ b/app/views/comments/destroy.turbo_stream.erb
@@ -1,0 +1,1 @@
+<turbo-stream action="remove" target="comment_<%= @comment.id %>"></turbo-stream>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -44,7 +44,16 @@
   </div>
   <h3>コメントを追加する</h3>
     <% if user_signed_in? %>
-      <%= form_with(model: [@post, Comment.new], id: 'comment_form') do |f| %>
+      <%= form_with(model: [@post, @comment], id: 'comment_form') do |f| %>
+        <% if @comment&.errors.any? %>
+          <div class="error-messages">
+            <ul>
+              <% @comment.errors.full_messages.each do |msg| %>
+                <li><%= msg %></li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
         <div>
           <%= f.label :content, "コメント:" %>
           <%= f.text_area :content, rows: 3 %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -40,16 +40,11 @@
   </div>
   <h2 id="comments">コメント一覧</h2>
   <div id="comments-section">
-    <% @post.comments.each do |comment| %>
-      <div class="comment">
-        <strong><%= comment.user.nickname %></strong>:
-        <p><%= comment.content %></p>
-      </div>
-    <% end %>
+    <%= render partial: "comments/comment", collection: @comments, as: :comment, locals: { current_user: current_user } %>
   </div>
   <h3>コメントを追加する</h3>
     <% if user_signed_in? %>
-      <%= form_with(model: [@post, Comment.new], id: 'comment_form', data: { turbo_frame: 'comments' }) do |f| %>
+      <%= form_with(model: [@post, Comment.new], id: 'comment_form') do |f| %>
         <div>
           <%= f.label :content, "コメント:" %>
           <%= f.text_area :content, rows: 3 %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,8 @@
+ja:
+  activerecord:
+    errors:
+      models:
+        comment:
+          attributes:
+            content:
+              blank: "コメントを入力してください。"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   root "posts#index"
   resources :posts do
     resource :like, only: [:create, :destroy]  # 単一のいいねを管理
-    resources :comments, only: [:create]
+    resources :comments, only: [:create, :destroy]
   end  
   resources :users, only: [:show] do
     get 'diagnosis', to: 'diagnosis#select_cat', as: :select_diagnosis_cat


### PR DESCRIPTION
#What
-投稿に対するコメントを削除できる機能を追加しました。
-コメントの投稿者のみが削除できるように制御しました。
-削除ボタンを各コメントに設置し、クリックすると対象のコメントが削除されるようにしました。
-Turbo Stream を使用して、削除後にページ全体をリロードせずにコメント部分のみを更新するようにしました。

#Why
-ユーザーが誤って投稿したコメントを削除したい場合に対応するため。
-コメントの内容が不要、誤り、あるいは不適切だった場合、投稿者がその場で修正する手段が必要なため。
-ユーザー体験を向上させ、アプリの利便性を高めるため。
-Turbo Stream を使用することでページの再読み込みを避け、シームレスな削除操作を可能にし、ユーザーエクスペリエンスを向上させるため。