### PR TITLE
コメント編集機能

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -104,3 +104,44 @@
 .delete-comment-button:hover {
   background-color: #c0392b;
 }
+.comment-actions-wrapper {
+  position: relative;
+  display: inline-block;
+  color: #444;
+}
+
+.dropdown-icon {
+  width: 20px;
+  height: 20px;
+  background-color: #d3902c;
+  cursor: pointer;
+}
+
+.dropdown-menu {
+  display: none;
+  position: absolute;
+  white-space: nowrap; /* 横並びで要素が折り返されないようにする */
+  top: 0;
+  left: 300%;
+  background-color: #ebeaea;
+  border: 1px solid #ccc;
+  padding: 10px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);
+  border-radius: 5px;
+  color: #fff;
+}
+
+.dropdown-menu a {
+  display: block;
+  padding: 5px;
+  text-decoration: none;
+  color: #333;
+}
+
+.dropdown-menu a:hover {
+  background-color: #f0f0f0;
+}
+
+.dropdown-menu.show {
+  display: block;
+}

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -38,26 +38,21 @@ class CommentsController < ApplicationController
   end
 
   def edit
+    @comment = Comment.find(params[:id])
     respond_to do |format|
-      format.turbo_stream
-      format.html # フォールバック用
+      format.html # 通常のリクエストに対応
+      format.turbo_stream do
+        render turbo_stream: turbo_stream.replace("comment_#{@comment.id}", partial: 'comments/form',
+                                                                            locals: { comment: @comment })
+      end
     end
   end
 
   def update
     if @comment.update(comment_params)
-      respond_to do |format|
-        format.turbo_stream
-        format.html { redirect_to @post, notice: 'コメントが編集されました。' }
-      end
+      redirect_to post_path(@post), notice: 'コメントが更新されました。'
     else
-      respond_to do |format|
-        format.turbo_stream do
-          render turbo_stream: turbo_stream.replace("comment_#{@comment.id}", partial: 'comments/form',
-                                                                              locals: { comment: @comment })
-        end
-        format.html { render :edit, alert: '編集に失敗しました。' }
-      end
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,7 +1,7 @@
 class CommentsController < ApplicationController
-  before_action :authenticate_user!
+  before_action :authenticate_user!, only: [:edit, :update, :destroy]
   before_action :set_post
-  before_action :set_comment, only: [:destroy]
+  before_action :set_comment, only: [:destroy, :update, :destroy]
 
   def create
     @comment = @post.comments.new(comment_params)
@@ -33,6 +33,30 @@ class CommentsController < ApplicationController
     else
       respond_to do |format|
         format.html { redirect_to @post, alert: '他のユーザーのコメントは削除できません。' }
+      end
+    end
+  end
+
+  def edit
+    respond_to do |format|
+      format.turbo_stream
+      format.html # フォールバック用
+    end
+  end
+
+  def update
+    if @comment.update(comment_params)
+      respond_to do |format|
+        format.turbo_stream
+        format.html { redirect_to @post, notice: 'コメントが編集されました。' }
+      end
+    else
+      respond_to do |format|
+        format.turbo_stream do
+          render turbo_stream: turbo_stream.replace("comment_#{@comment.id}", partial: 'comments/form',
+                                                                              locals: { comment: @comment })
+        end
+        format.html { render :edit, alert: '編集に失敗しました。' }
       end
     end
   end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,5 +2,5 @@
 import "@hotwired/turbo-rails"
 import "controllers"
 import Rails from "@rails/ujs";
-
+import "./comments_dropdown";
 Rails.start();

--- a/app/javascript/comments_dropdown.js
+++ b/app/javascript/comments_dropdown.js
@@ -1,0 +1,30 @@
+function setupDropdownListeners() {
+  // 既存のイベントリスナーを削除
+  document.querySelectorAll(".dropdown-icon").forEach(icon => {
+    icon.removeEventListener("click", toggleDropdown); // 既存のリスナー削除
+    icon.addEventListener("click", toggleDropdown); // 新しく追加
+  });
+}
+
+function toggleDropdown(event) {
+  const icon = event.currentTarget;
+  const menuId = icon.id.replace("dropdown-icon-", "dropdown-menu-");
+  const menu = document.getElementById(menuId);
+
+  // 他のメニューを閉じる
+  document.querySelectorAll(".dropdown-menu").forEach(m => {
+    if (m !== menu) m.classList.remove("show");
+  });
+
+  // 現在のメニューの表示・非表示を切り替え
+  menu.classList.toggle("show");
+}
+// ✅ `window` に登録してグローバルスコープで使えるようにする
+window.setupDropdownListeners = setupDropdownListeners;
+// 初回ロード時の設定
+document.addEventListener("DOMContentLoaded", setupDropdownListeners);
+
+// Turbo Driveがロードされるたびに再設定
+document.addEventListener("turbo:load", setupDropdownListeners);
+document.addEventListener("turbo:frame-load", setupDropdownListeners);
+

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -5,9 +5,18 @@
   </div>
 
   <% if current_user && comment.user_id.to_i == current_user.id.to_i %>
-    <%= link_to '削除', post_comment_path(comment.post, comment), 
-        method: :delete, 
-        data: { turbo_confirm: "本当に削除しますか？" }, 
-        class: "delete-comment-button" %>
+  <div class="comment-actions-wrapper">
+    <span class="dropdown-icon" id="dropdown-icon-<%= comment.id %>">
+      <%= image_tag 'arrow_top.png', alt: "メニューアイコン" %>
+    </span>
+
+    <div class="dropdown-menu" id="dropdown-menu-<%= comment.id %>">
+      <%= link_to '編集', edit_post_comment_path(comment.post, comment), class: "edit-comment-button" %>
+      <%= link_to '削除', post_comment_path(comment.post, comment), 
+          method: :delete, 
+          data: { turbo_confirm: "本当に削除しますか？" }, 
+          class: "delete-comment-button" %>
+    </div>
+  </div>
   <% end %>
 </div>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -14,6 +14,6 @@
     <%= f.text_area :content, rows: 3 %>
   </div>
   <div>
-    <%= f.submit "コメントする", class: "comment-submit-button" %>
+    <%= f.submit comment.new_record? ? "コメントする" : "更新する", class: "comment-submit-button" %>
   </div>
 <% end %>

--- a/app/views/comments/create.turbo_stream.erb
+++ b/app/views/comments/create.turbo_stream.erb
@@ -1,6 +1,6 @@
 <turbo-stream action="append" target="comments-section">
   <template>
-  <%= render "comments/comment", comment: @comment %>
+    <%= render partial: "comments/comment", locals: { comment: @comment }, formats: :html %>
   </template>
 </turbo-stream>
 
@@ -15,5 +15,17 @@
         <%= f.submit "コメントする", class: "comment-submit-button" %>
       </div>
     <% end %>
+  </template>
+</turbo-stream>
+
+<turbo-stream action="append" target="comments-section">
+  <template>
+    <%= render partial: "comments/comment", locals: { comment: @comment }, formats: [:html] %>
+  </template>
+</turbo-stream>
+
+<turbo-stream action="after" target="comments-section">
+  <template>
+    <script>setupDropdownListeners();</script>
   </template>
 </turbo-stream>

--- a/app/views/comments/edit.html.erb
+++ b/app/views/comments/edit.html.erb
@@ -1,0 +1,22 @@
+<h2>コメントを編集する</h2>
+
+<%= form_with(model: [@post, @comment], local: true) do |f| %>
+  <% if @comment.errors.any? %>
+    <div class="error-messages">
+      <ul>
+        <% @comment.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= f.label :content, "コメント:" %>
+    <%= f.text_area :content, rows: 3 %>
+  </div>
+
+  <div>
+    <%= f.submit "更新する", class: "comment-submit-button" %>
+  </div>
+<% end %>

--- a/app/views/comments/update.turbo_stream.erb
+++ b/app/views/comments/update.turbo_stream.erb
@@ -1,0 +1,9 @@
+<%= form_with(model: [@post, @comment], local: true) do |f| %>
+  <div>
+    <%= f.label :content, "コメント:" %>
+    <%= f.text_area :content, rows: 3 %>
+  </div>
+  <div>
+    <%= f.submit "更新する" %>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   root "posts#index"
   resources :posts do
     resource :like, only: [:create, :destroy]  # 単一のいいねを管理
-    resources :comments, only: [:create, :destroy]
+    resources :comments, only: [:create, :destroy, :edit, :update]
   end  
   resources :users, only: [:show] do
     get 'diagnosis', to: 'diagnosis#select_cat', as: :select_diagnosis_cat


### PR DESCRIPTION
#Why
-コメントの編集ができない ため、ユーザーが投稿したコメントを修正する手段がなかった。
-投稿ミスや修正したい内容があっても、 削除して再投稿するしかない 状況だった。
-使い勝手を向上させるために、既存のコメントを編集できる機能 を追加する。

#What
-コメント編集画面の作成
-edit.html.erb を追加し、コメントの編集フォームを表示できるようにした。
-comments_controller.rb に edit アクションを追加。
-コメント更新処理の実装
-update アクションを実装し、編集内容をデータベースに保存できるようにした。
-update.turbo_stream.erb を作成し、Turbo Stream で編集後のコメントを即時更新するようにした。
-プルダウンメニューの追加
-コメントごとに 編集・削除ボタンをプルダウンで表示 できるようにした。
-JavaScript (comments_dropdown.js) を作成し、クリックでメニューを開閉できるように実装。
-UIの調整
-編集ボタンのデザインを追加 し、ユーザーが簡単に操作できるようにした。
-プルダウンメニューの位置調整（ボタンの横に表示されるようにした）。
-Turbo対応
-コメントを編集後、 ページをリロードせずに変更が反映 されるように turbo_stream を使用。